### PR TITLE
added feature to use browser profile 

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,11 @@ Output:
             <td>Boolean</td>
             <td>Whether to run crawler headlessly?. Default is <code>True</code></td>
         </tr>
+        <tr>
+            <td>browser_profile</td>
+            <td>String</td>
+            <td>Path to the browser profile where cookies are stored and can be used for scraping data in an authenticated way.</td>
+        </tr>
     </tbody>
 </table>
 
@@ -515,6 +520,11 @@ Output:
             <td>Boolean</td>
             <td>Whether to run crawler headlessly?. Default is <code>True</code></td>
         </tr>
+        <tr>
+            <td>browser_profile</td>
+            <td>String</td>
+            <td>Path to the browser profile where cookies are stored and can be used for scraping data in an authenticated way.</td>
+        </tr>
     </tbody>
 </table>
 </div>
@@ -640,6 +650,7 @@ Output and key of the output is the same as `scrap_keyword`:
 | tweets_count  | int                | Number of posts to scrap. default 10.                                                                                                  |
 | output_format | str                | The output format whether JSON or CSV. Default json.                                                                                   |
 | directory     | str                | Directory to save output file. Deafult current working directory.                                                                      |
+| browser_profile | str | Path to the browser profile where cookies are stored and can be used for scraping data in an authenticated way. |
 
 </div>
 

--- a/twitter_scraper_selenium/driver_initialization.py
+++ b/twitter_scraper_selenium/driver_initialization.py
@@ -14,12 +14,14 @@ import logging
 
 logging.getLogger().setLevel(logging.INFO)
 
+
 class Initializer:
 
-    def __init__(self, browser_name, headless, proxy=None):
+    def __init__(self, browser_name, headless, proxy=None, profile=None):
         self.browser_name = browser_name
         self.proxy = proxy
         self.headless = headless
+        self.profile = profile
 
     def set_properties(self, browser_option):
         """adds capabilities to the driver"""
@@ -27,6 +29,9 @@ class Initializer:
         if self.headless:
             browser_option.add_argument(
                 '--headless')  # runs browser in headless mode
+        if self.profile and self.browser_name.lower() == 'chrome':
+            browser_option.add_argument(
+                'user-data-dir={}'.format(self.profile))
         browser_option.add_argument('--no-sandbox')
         browser_option.add_argument("--disable-dev-shm-usage")
         browser_option.add_argument('--ignore-certificate-errors')
@@ -57,6 +62,10 @@ class Initializer:
             return webdriver.Chrome(service=ChromeService(ChromeDriverManager().install()), options=self.set_properties(browser_option))
         elif browser_name.lower() == "firefox":
             browser_option = CustomFireFoxOptions()
+            if self.profile:
+                logging.info('Loading Profile from {}'.format(self.profile))
+                profile_path = webdriver.FirefoxProfile(self.profile)
+                browser_option.profile = profile_path
             if self.proxy is not None:
                 options = {
                     'https': 'https://{}'.format(self.proxy.replace(" ", "")),
@@ -64,7 +73,6 @@ class Initializer:
                     'no_proxy': 'localhost, 127.0.0.1'
                 }
                 logging.info("Using Proxy: {}".format(self.proxy))
-
                 return webdriver.Firefox(service=FirefoxService(executable_path=GeckoDriverManager().install()),
                                          options=self.set_properties(browser_option), seleniumwire_options=options)
 

--- a/twitter_scraper_selenium/keyword.py
+++ b/twitter_scraper_selenium/keyword.py
@@ -17,7 +17,7 @@ class Keyword:
     """this class needs to be instantiated in order to find something
     on twitter related to keywords"""
 
-    def __init__(self, keyword, browser, proxy, tweets_count, url, headless):
+    def __init__(self, keyword, browser, proxy, tweets_count, url, headless, browser_profile):
         self.keyword = keyword
         self.URL = url
         self.driver = ""
@@ -27,11 +27,12 @@ class Keyword:
         self.posts_data = {}
         self.retry = 10
         self.headless = headless
+        self.browser_profile = browser_profile
 
     def __start_driver(self):
         """changes the class member __driver value to driver on call"""
         self.__driver = Initializer(
-            self.browser, self.headless, self.proxy).init()
+            self.browser, self.headless, self.proxy, self.browser_profile).init()
 
     def __close_driver(self):
         self.__driver.close()
@@ -170,7 +171,7 @@ def json_to_csv(filename, json_data, directory):
 def scrap_keyword(keyword, browser="firefox", until=None,
                   since=None, since_id=None, max_id=None, within_time=None,
                   proxy=None, tweets_count=10, output_format="json",
-                  filename="", directory=os.getcwd(), headless=True):
+                  filename="", directory=os.getcwd(), headless=True, browser_profile=None):
     """
     Returns tweets data in CSV or JSON.
 
@@ -198,11 +199,13 @@ def scrap_keyword(keyword, browser="firefox", until=None,
     max_id(integer): At or before (inclusive) a specified Snowflake ID.
 
     within_time(string): Search within the last number of days, hours, minutes, or seconds.
+
+    browser_profile(string): Path of Browser Profile where cookies might be located to scrap data in authenticated way.
     """
     URL = Scraping_utilities._Scraping_utilities__url_generator(keyword, since=since, until=until,
                                                                 since_id=since_id, max_id=max_id, within_time=within_time)
     keyword_bot = Keyword(keyword, browser=browser, url=URL,
-                          proxy=proxy, tweets_count=tweets_count, headless=headless)
+                          proxy=proxy, tweets_count=tweets_count, headless=headless, browser_profile=browser_profile)
     data = keyword_bot.scrap()
     if output_format.lower() == "json":
         if filename == '':

--- a/twitter_scraper_selenium/profile.py
+++ b/twitter_scraper_selenium/profile.py
@@ -17,7 +17,7 @@ class Profile:
     """this class needs to be instantiated in orer to scrape post of some
     twitter profile"""
 
-    def __init__(self, twitter_username, browser, proxy, tweets_count, headless):
+    def __init__(self, twitter_username, browser, proxy, tweets_count, headless, browser_profile):
         self.twitter_username = twitter_username
         self.URL = "https://twitter.com/{}".format(twitter_username.lower())
         self.__driver = ""
@@ -27,11 +27,12 @@ class Profile:
         self.posts_data = {}
         self.retry = 10
         self.headless = headless
+        self.browser_profile = browser_profile
 
     def __start_driver(self):
         """changes the class member __driver value to driver on call"""
         self.__driver = Initializer(
-            self.browser, self.headless, self.proxy).init()
+            self.browser, self.headless, self.proxy, self.browser_profile).init()
 
     def __close_driver(self):
         self.__driver.close()
@@ -167,7 +168,7 @@ def json_to_csv(filename, json_data, directory):
     logging.info('Data Successfully Saved to {}.csv'.format(filename))
 
 
-def scrap_profile(twitter_username, browser="firefox", proxy=None, tweets_count=10, output_format="json", filename="", directory=os.getcwd(), headless=True):
+def scrap_profile(twitter_username, browser="firefox", proxy=None, tweets_count=10, output_format="json", filename="", directory=os.getcwd(), headless=True, browser_profile = None):
     """
     Returns tweets data in CSV or JSON.
 
@@ -186,10 +187,10 @@ def scrap_profile(twitter_username, browser="firefox", proxy=None, tweets_count=
 
     directory(string): If output_format parameter is set to CSV, then it is valid for directory parameter to be passed. If not passed then CSV file will be saved in current working directory.
 
-
+    browser_profile(string): Path of Browser Profile where cookies might be located to scrap data in authenticated way.
     """
     profile_bot = Profile(twitter_username, browser,
-                          proxy, tweets_count, headless)
+                          proxy, tweets_count, headless, browser_profile)
     data = profile_bot.scrap()
     if output_format.lower() == "json":
         if filename == '':

--- a/twitter_scraper_selenium/topic.py
+++ b/twitter_scraper_selenium/topic.py
@@ -18,6 +18,7 @@ def scrap_topic(
     output_format: str = "json",
     directory: str = None,
     headless: bool = True,
+    browser_profile = None
 ):
     """
     Returns tweets data in CSV or JSON.
@@ -30,6 +31,7 @@ def scrap_topic(
         tweets_count: Number of posts to scrap. Default is 10.
         output_format: The output format, whether JSON or CSV. Default is JSON.
         directory: If output parameter is set to CSV, then it is valid for directory parameter to be passed. If not passed then CSV file will be saved in current working directory.
+        browser_profile: Path of Browser Profile where cookies might be located to scrap data in authenticated way.
     """
     pass
     if directory is None:
@@ -41,6 +43,7 @@ def scrap_topic(
         headless=headless,
         proxy=proxy,
         tweets_count=tweets_count,
+        browser_profile=browser_profile
     )
     data = keyword_bot.scrap()
     if output_format.lower() == "json":


### PR DESCRIPTION
- Earlier it was possible to scrape only with an unauthenticated way and use a proxy in case of hitting the sign-up modals. This new feature will be able to provide a way to scrape data in an authenticated way. As mentioned in #29 
- User needs to login into the Twitter account once and get the browser profile's path. Pass it to the crawler with the argument `browser_profile=YOUR_BROWSER_PROFILE_PATH` the crawler will use that path of the browser for scraping. 