### PR TITLE
Add Xquik search and fix failed driver cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
     </ul>
     </li></ul>
     <!---->
+    <ul><li><a href="#xquik-search">Searching X with Xquik</a></li></ul>
     <ul>
     <li><a href="#profile">Scraping profile's tweets</a>
     <ul>
@@ -155,11 +156,67 @@ Usage</h2>
 <td>Browser Automation & HTTP Request</td>
 <td>Fast</td>
 </tr>
+<tr>
+<td><code>search_tweets_with_xquik()</code></td>
+<td>Search public X posts through the Xquik API.</td>
+<td>HTTP Request</td>
+<td>Fast</td>
+</tr>
 </table>
 <p>
 Note: HTTP Request Method sends the request to Twitter's API directly for scraping data, and Browser Automation visits that page, scroll while collecting the data.</p>
 </div>
 <br>
+<hr>
+<h3 id="xquik-search">Search X with Xquik</h3>
+
+<p>
+Use the optional Xquik helper for authenticated, read-only X search without
+launching Selenium. Create an API key, then store it outside your source code:
+</p>
+
+```bash
+export XQUIK_API_KEY="<your_api_key>"
+```
+
+```python
+from twitter_scraper_selenium import search_tweets_with_xquik
+
+page = search_tweets_with_xquik(
+    "python #opensource",
+    tweets_count=25,
+    query_type="Latest",
+)
+
+for tweet in page["tweets"]:
+    print(tweet["text"])
+
+if page.get("has_next_page"):
+    next_page = search_tweets_with_xquik(
+        "python #opensource",
+        tweets_count=25,
+        query_type="Latest",
+        cursor=page["next_cursor"],
+    )
+```
+
+<p>
+<code>tweets_count</code> accepts 1 to 200 posts per request.
+<code>query_type</code> accepts <code>Latest</code> or <code>Top</code>.
+Use <code>since_time</code> and <code>until_time</code> for date bounds.
+Pass <code>next_cursor</code> back as <code>cursor</code> to continue.
+The helper returns the raw JSON response and raises
+<code>XquikApiError</code> for authentication, HTTP, network, or response
+errors. See the
+<a href="https://docs.xquik.com/api-reference/x/search-tweets">Search Tweets API documentation</a>
+for response fields and search operators.
+</p>
+
+<p>
+Xquik is an independent third-party service. Not affiliated with X Corp.
+"Twitter" and "X" are trademarks of X Corp.
+</p>
+
 <hr>
 <h3 id="profileDetail">To scrape twitter profile details:</h3>
 <div id="profileDetailExample">

--- a/tests/test_profile_driver_cleanup.py
+++ b/tests/test_profile_driver_cleanup.py
@@ -1,0 +1,83 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+PACKAGE_NAME = "profile_cleanup_test_package"
+PACKAGE_PATH = Path(__file__).resolve().parents[1] / "twitter_scraper_selenium"
+
+
+def load_profile_module():
+    package = types.ModuleType(PACKAGE_NAME)
+    package.__path__ = [str(PACKAGE_PATH)]
+    sys.modules[PACKAGE_NAME] = package
+
+    dependencies = (
+        ("driver_initialization", "Initializer"),
+        ("driver_utils", "Utilities"),
+        ("element_finder", "Finder"),
+    )
+    for module_name, attribute_name in dependencies:
+        module = types.ModuleType("{}.{}".format(PACKAGE_NAME, module_name))
+        setattr(module, attribute_name, object)
+        sys.modules[module.__name__] = module
+
+    spec = importlib.util.spec_from_file_location(
+        "{}.profile".format(PACKAGE_NAME),
+        PACKAGE_PATH / "profile.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+profile_module = load_profile_module()
+
+
+class FailingInitializer:
+    def __init__(self, browser, headless, proxy):
+        pass
+
+    def init(self):
+        raise RuntimeError("driver start failed")
+
+
+class FakeDriver:
+    def __init__(self):
+        self.close_calls = 0
+        self.quit_calls = 0
+
+    def close(self):
+        self.close_calls += 1
+
+    def quit(self):
+        self.quit_calls += 1
+
+
+class ProfileDriverCleanupTests(unittest.TestCase):
+    def test_startup_failure_does_not_raise_cleanup_attribute_error(self):
+        profile_module.Initializer = FailingInitializer
+        profile = profile_module.Profile("xquik", "firefox", None, 1, True)
+
+        with self.assertLogs(profile_module.logger, level="ERROR") as logs:
+            result = profile.scrap()
+
+        self.assertIsNone(result)
+        self.assertIn("driver start failed", logs.output[0])
+
+    def test_cleanup_closes_an_active_driver_once(self):
+        profile = profile_module.Profile("xquik", "firefox", None, 1, True)
+        driver = FakeDriver()
+        profile._Profile__driver = driver
+
+        profile._Profile__close_driver()
+        profile._Profile__close_driver()
+
+        self.assertEqual(1, driver.close_calls)
+        self.assertEqual(1, driver.quit_calls)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_xquik_api.py
+++ b/tests/test_xquik_api.py
@@ -1,0 +1,68 @@
+import importlib.util
+import unittest
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "twitter_scraper_selenium"
+    / "xquik_api.py"
+)
+SPEC = importlib.util.spec_from_file_location("xquik_api", MODULE_PATH)
+xquik_api = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(xquik_api)
+
+
+class FakeResponse:
+    def read(self):
+        return b'{"data": [{"id": "1", "text": "hello"}]}'
+
+
+class FakeOpener:
+    def __init__(self):
+        self.request = None
+        self.timeout = None
+
+    def __call__(self, request, timeout):
+        self.request = request
+        self.timeout = timeout
+        return FakeResponse()
+
+
+class XquikApiTests(unittest.TestCase):
+    def test_builds_search_request(self):
+        opener = FakeOpener()
+
+        result = xquik_api.search_tweets_with_xquik(
+            "python",
+            tweets_count=15,
+            api_key="test-key",
+            opener=opener,
+        )
+
+        parsed_url = urlparse(opener.request.full_url)
+        query = parse_qs(parsed_url.query)
+        self.assertEqual("xquik.com", parsed_url.netloc)
+        self.assertEqual(["python"], query["q"])
+        self.assertEqual(["Latest"], query["queryType"])
+        self.assertEqual(["15"], query["limit"])
+        self.assertEqual("test-key", opener.request.headers["X-api-key"])
+        self.assertEqual(30, opener.timeout)
+        self.assertEqual({"data": [{"id": "1", "text": "hello"}]}, result)
+
+    def test_requires_api_key(self):
+        with self.assertRaises(xquik_api.XquikApiError):
+            xquik_api.search_tweets_with_xquik("xquik", api_key="")
+
+    def test_validates_tweets_count(self):
+        with self.assertRaises(ValueError):
+            xquik_api.search_tweets_with_xquik(
+                "xquik",
+                tweets_count=0,
+                api_key="test-key",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_xquik_api.py
+++ b/tests/test_xquik_api.py
@@ -1,13 +1,12 @@
 import importlib.util
 import unittest
 from pathlib import Path
+from urllib.error import HTTPError, URLError
 from urllib.parse import parse_qs, urlparse
 
 
 MODULE_PATH = (
-    Path(__file__).resolve().parents[1]
-    / "twitter_scraper_selenium"
-    / "xquik_api.py"
+    Path(__file__).resolve().parents[1] / "twitter_scraper_selenium" / "xquik_api.py"
 )
 SPEC = importlib.util.spec_from_file_location("xquik_api", MODULE_PATH)
 xquik_api = importlib.util.module_from_spec(SPEC)
@@ -15,19 +14,30 @@ SPEC.loader.exec_module(xquik_api)
 
 
 class FakeResponse:
+    def __init__(self, body=b'{"data": [{"id": "1", "text": "hello"}]}'):
+        self.body = body
+        self.closed = False
+
     def read(self):
-        return b'{"data": [{"id": "1", "text": "hello"}]}'
+        return self.body
+
+    def close(self):
+        self.closed = True
 
 
 class FakeOpener:
-    def __init__(self):
+    def __init__(self, response=None, error=None):
         self.request = None
         self.timeout = None
+        self.response = response if response is not None else FakeResponse()
+        self.error = error
 
     def __call__(self, request, timeout):
         self.request = request
         self.timeout = timeout
-        return FakeResponse()
+        if self.error is not None:
+            raise self.error
+        return self.response
 
 
 class XquikApiTests(unittest.TestCase):
@@ -50,17 +60,92 @@ class XquikApiTests(unittest.TestCase):
         self.assertEqual("test-key", opener.request.headers["X-api-key"])
         self.assertEqual(30, opener.timeout)
         self.assertEqual({"data": [{"id": "1", "text": "hello"}]}, result)
+        self.assertTrue(opener.response.closed)
+
+    def test_includes_optional_search_parameters(self):
+        opener = FakeOpener()
+
+        xquik_api.search_tweets_with_xquik(
+            "from:python",
+            tweets_count=200,
+            query_type="Top",
+            cursor="next-page",
+            since_time="2026-07-01",
+            until_time="2026-07-29",
+            api_key="test-key",
+            opener=opener,
+        )
+
+        query = parse_qs(urlparse(opener.request.full_url).query)
+        self.assertEqual(["200"], query["limit"])
+        self.assertEqual(["Top"], query["queryType"])
+        self.assertEqual(["next-page"], query["cursor"])
+        self.assertEqual(["2026-07-01"], query["sinceTime"])
+        self.assertEqual(["2026-07-29"], query["untilTime"])
 
     def test_requires_api_key(self):
         with self.assertRaises(xquik_api.XquikApiError):
-            xquik_api.search_tweets_with_xquik("xquik", api_key="")
+            xquik_api.search_tweets_with_xquik("xquik", api_key=" ")
 
-    def test_validates_tweets_count(self):
-        with self.assertRaises(ValueError):
+    def test_validates_search_parameters(self):
+        invalid_arguments = (
+            {"query": " ", "api_key": "test-key"},
+            {"query": "xquik", "tweets_count": 0, "api_key": "test-key"},
+            {"query": "xquik", "tweets_count": 201, "api_key": "test-key"},
+            {
+                "query": "xquik",
+                "query_type": "Popular",
+                "api_key": "test-key",
+            },
+        )
+        for arguments in invalid_arguments:
+            with self.subTest(arguments=arguments):
+                with self.assertRaises(ValueError):
+                    xquik_api.search_tweets_with_xquik(**arguments)
+
+    def test_wraps_invalid_json_and_closes_response(self):
+        opener = FakeOpener(response=FakeResponse(b"not-json"))
+
+        with self.assertRaisesRegex(
+            xquik_api.XquikApiError,
+            "invalid JSON",
+        ):
             xquik_api.search_tweets_with_xquik(
                 "xquik",
-                tweets_count=0,
                 api_key="test-key",
+                opener=opener,
+            )
+
+        self.assertTrue(opener.response.closed)
+
+    def test_wraps_http_errors(self):
+        response = FakeResponse()
+        error = HTTPError(
+            xquik_api.XQUIK_SEARCH_URL,
+            429,
+            "Too Many Requests",
+            None,
+            response,
+        )
+
+        with self.assertRaisesRegex(xquik_api.XquikApiError, "HTTP 429"):
+            xquik_api.search_tweets_with_xquik(
+                "xquik",
+                api_key="test-key",
+                opener=FakeOpener(error=error),
+            )
+
+        self.assertTrue(response.closed)
+
+    def test_wraps_network_errors(self):
+        with self.assertRaisesRegex(
+            xquik_api.XquikApiError,
+            "network connection",
+        ):
+            xquik_api.search_tweets_with_xquik(
+                "xquik",
+                api_key="test-key",
+                opener=FakeOpener(error=URLError("offline")),
             )
 
 

--- a/twitter_scraper_selenium/__init__.py
+++ b/twitter_scraper_selenium/__init__.py
@@ -9,8 +9,9 @@ from .keyword_api import scrape_keyword_with_api
 from .profile_details import get_profile_details
 from .topic_api import scrape_topic_with_api
 from .profile_api import scrape_profile_with_api
+from .xquik_api import search_tweets_with_xquik
 # __all__ = ["Initializer",
 #           "Utilities", "Finder",
 #           "Scraping_utilities","scrap_profile","scrap_keyword"]
 __all__ = ["scrape_profile", "scrape_keyword",
-           "scrape_topic", "scrape_keyword_with_api", "get_profile_details", "scrape_topic_with_api", "scrape_profile_with_api"]
+           "scrape_topic", "scrape_keyword_with_api", "get_profile_details", "scrape_topic_with_api", "scrape_profile_with_api", "search_tweets_with_xquik"]

--- a/twitter_scraper_selenium/__init__.py
+++ b/twitter_scraper_selenium/__init__.py
@@ -1,7 +1,7 @@
-#from .driver_initialization import Initializer
-#from .driver_utils import Utilities
-#from .element_finder import Finder
-#from .scraping_utilities import Scraping_utilities
+# from .driver_initialization import Initializer
+# from .driver_utils import Utilities
+# from .element_finder import Finder
+# from .scraping_utilities import Scraping_utilities
 from .keyword import scrape_keyword
 from .profile import scrape_profile
 from .topic import scrape_topic
@@ -9,9 +9,19 @@ from .keyword_api import scrape_keyword_with_api
 from .profile_details import get_profile_details
 from .topic_api import scrape_topic_with_api
 from .profile_api import scrape_profile_with_api
-from .xquik_api import search_tweets_with_xquik
+from .xquik_api import XquikApiError, search_tweets_with_xquik
+
 # __all__ = ["Initializer",
 #           "Utilities", "Finder",
 #           "Scraping_utilities","scrap_profile","scrap_keyword"]
-__all__ = ["scrape_profile", "scrape_keyword",
-           "scrape_topic", "scrape_keyword_with_api", "get_profile_details", "scrape_topic_with_api", "scrape_profile_with_api", "search_tweets_with_xquik"]
+__all__ = [
+    "XquikApiError",
+    "get_profile_details",
+    "scrape_keyword",
+    "scrape_keyword_with_api",
+    "scrape_profile",
+    "scrape_profile_with_api",
+    "scrape_topic",
+    "scrape_topic_with_api",
+    "search_tweets_with_xquik",
+]

--- a/twitter_scraper_selenium/profile.py
+++ b/twitter_scraper_selenium/profile.py
@@ -25,7 +25,7 @@ class Profile:
     def __init__(self, twitter_username, browser, proxy, tweets_count, headless):
         self.twitter_username = twitter_username
         self.URL = "https://twitter.com/{}".format(twitter_username.lower())
-        self.__driver = ""
+        self.__driver = None
         self.browser = browser
         self.proxy = proxy
         self.tweets_count = tweets_count
@@ -39,8 +39,14 @@ class Profile:
             self.browser, self.headless, self.proxy).init()
 
     def __close_driver(self):
-        self.__driver.close()
-        self.__driver.quit()
+        driver = self.__driver
+        if driver is None:
+            return
+        self.__driver = None
+        try:
+            driver.close()
+        finally:
+            driver.quit()
 
     def __check_tweets_presence(self, tweet_list):
         if len(tweet_list) <= 0:

--- a/twitter_scraper_selenium/xquik_api.py
+++ b/twitter_scraper_selenium/xquik_api.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+import json
+import os
+from typing import Callable, Optional
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+XQUIK_SEARCH_URL = "https://xquik.com/api/v1/x/tweets/search"
+
+
+class XquikApiError(Exception):
+    """Raised when Xquik search cannot run."""
+
+
+def _resolve_api_key(api_key: Optional[str]) -> str:
+    resolved = api_key or os.getenv("XQUIK_API_KEY")
+    if not resolved:
+        raise XquikApiError("XQUIK_API_KEY is required for Xquik search")
+    return resolved
+
+
+def _decode_json_response(response):
+    payload = response.read()
+    if isinstance(payload, bytes):
+        payload = payload.decode("utf-8")
+    return json.loads(payload)
+
+
+def search_tweets_with_xquik(
+    query: str,
+    tweets_count: int = 10,
+    query_type: str = "Latest",
+    cursor: Optional[str] = None,
+    since_time: Optional[str] = None,
+    until_time: Optional[str] = None,
+    api_key: Optional[str] = None,
+    opener: Optional[Callable] = None,
+):
+    """Search X posts through Xquik without launching Selenium."""
+
+    if not query:
+        raise ValueError("query is required")
+    if tweets_count < 1 or tweets_count > 100:
+        raise ValueError("tweets_count must be between 1 and 100")
+
+    params = {
+        "q": query,
+        "queryType": query_type,
+        "limit": str(tweets_count),
+    }
+    optional_params = {
+        "cursor": cursor,
+        "sinceTime": since_time,
+        "untilTime": until_time,
+    }
+    for key, value in optional_params.items():
+        if value is not None:
+            params[key] = value
+
+    request = Request(
+        "{}?{}".format(XQUIK_SEARCH_URL, urlencode(params)),
+        headers={
+            "Accept": "application/json",
+            "x-api-key": _resolve_api_key(api_key),
+        },
+    )
+    transport = opener or urlopen
+    response = transport(request, timeout=30)
+    return _decode_json_response(response)

--- a/twitter_scraper_selenium/xquik_api.py
+++ b/twitter_scraper_selenium/xquik_api.py
@@ -2,12 +2,14 @@
 
 import json
 import os
-from typing import Callable, Optional
+from typing import Any, Callable, Dict, Optional
+from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 
 XQUIK_SEARCH_URL = "https://xquik.com/api/v1/x/tweets/search"
+XQUIK_QUERY_TYPES = ("Latest", "Top")
 
 
 class XquikApiError(Exception):
@@ -15,17 +17,25 @@ class XquikApiError(Exception):
 
 
 def _resolve_api_key(api_key: Optional[str]) -> str:
-    resolved = api_key or os.getenv("XQUIK_API_KEY")
-    if not resolved:
+    resolved = api_key if api_key is not None else os.getenv("XQUIK_API_KEY")
+    if resolved is None or not resolved.strip():
         raise XquikApiError("XQUIK_API_KEY is required for Xquik search")
-    return resolved
+    return resolved.strip()
 
 
-def _decode_json_response(response):
+def _decode_json_response(response: Any) -> Any:
+    """Decode one JSON response from the Xquik API."""
     payload = response.read()
     if isinstance(payload, bytes):
         payload = payload.decode("utf-8")
     return json.loads(payload)
+
+
+def _close_response(response: Any) -> None:
+    """Close a response when its transport exposes a close method."""
+    close = getattr(response, "close", None)
+    if callable(close):
+        close()
 
 
 def search_tweets_with_xquik(
@@ -36,17 +46,19 @@ def search_tweets_with_xquik(
     since_time: Optional[str] = None,
     until_time: Optional[str] = None,
     api_key: Optional[str] = None,
-    opener: Optional[Callable] = None,
-):
-    """Search X posts through Xquik without launching Selenium."""
+    opener: Optional[Callable[..., Any]] = None,
+) -> Any:
+    """Return one paginated Xquik search response without launching Selenium."""
 
-    if not query:
+    if not query or not query.strip():
         raise ValueError("query is required")
-    if tweets_count < 1 or tweets_count > 100:
-        raise ValueError("tweets_count must be between 1 and 100")
+    if tweets_count < 1 or tweets_count > 200:
+        raise ValueError("tweets_count must be between 1 and 200")
+    if query_type not in XQUIK_QUERY_TYPES:
+        raise ValueError("query_type must be Latest or Top")
 
-    params = {
-        "q": query,
+    params: Dict[str, str] = {
+        "q": query.strip(),
         "queryType": query_type,
         "limit": str(tweets_count),
     }
@@ -67,5 +79,21 @@ def search_tweets_with_xquik(
         },
     )
     transport = opener or urlopen
-    response = transport(request, timeout=30)
-    return _decode_json_response(response)
+    response = None
+    try:
+        response = transport(request, timeout=30)
+        return _decode_json_response(response)
+    except HTTPError as error:
+        _close_response(error)
+        raise XquikApiError(
+            "Xquik request failed with HTTP {}".format(error.code)
+        ) from error
+    except (URLError, TimeoutError) as error:
+        raise XquikApiError(
+            "Xquik request failed. Check your network connection."
+        ) from error
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise XquikApiError("Xquik returned an invalid JSON response") from error
+    finally:
+        if response is not None:
+            _close_response(response)


### PR DESCRIPTION
## Summary

- Complete the optional Xquik search helper without launching Selenium.
- Match the current Search Tweets contract: `Latest` or `Top`, cursor pagination, date bounds, and 1 to 200 posts.
- Close HTTP responses and wrap authentication, HTTP, network, and invalid JSON failures in `XquikApiError`.
- Export the helper and error type, then document API-key and pagination usage.

## Independent Repository Fix

Fixes #63.

`Profile` previously stored an empty string before driver startup. When startup failed, cleanup called `.close()` on that string and hid the original failure. Cleanup now safely handles an unstarted driver, closes an active driver once, and always attempts `quit()` after `close()`.

## Validation

- `python3 -m unittest discover -s tests -v`: 9 passed
- `python3 -m compileall -q twitter_scraper_selenium tests`
- `python3 setup.py check --strict`
- Black checks for all new and fully touched Python modules
- Xquik documentation link check
- `git diff --check`

## Duplicate Check

Checked repository content and all-state pull requests for existing Xquik integrations before opening this pull request.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
